### PR TITLE
Remove *.zip

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ git clone https://github.com/ADeltaX/WSAGAScript
 cd WSAGAScript/\#IMAGES
 mv /mnt/path-to-extracted-msix/*.img .
 cd ../\#GAPPS
-cp /mnt/path-to-downloaded-gapps/*.zip .
+cp /mnt/path-to-downloaded-gapps/gapps-zip-file-name.zip .
 ```
 
 paths in wsl follow the same as windows after /mnt/ its just the drive letter then folder structure as normal. For example /mnt/c/users would be the c:\users folder


### PR DESCRIPTION
Replaced `cp /mnt/path-to-downloaded-gapps/*.zip .` with `cp /mnt/path-to-downloaded-gapps/gapps-zip-file-name.zip .` because some users might have other zip files there.