### PR TITLE
Fix SELinux Policy for gapps login in WSA 1.8.32828

### DIFF
--- a/README.md
+++ b/README.md
@@ -239,4 +239,4 @@ You are now root.
 
 # Currently known issues
 
-WSA 1.8.32822.0 may potentially prevent users from signing in to the Google Play Store, reasons are under investigation. See details and [#128](https://github.com/WSA-Community/WSAGAScript/issues/128) for previous version.
+- [Issues](https://github.com/WSA-Community/WSAGAScript/issues)

--- a/apply.sh
+++ b/apply.sh
@@ -154,9 +154,13 @@ chcon --reference=$MountPointProduct/etc $MountPointProduct/build.prop
 chcon --reference=$MountPointVendor/etc $MountPointVendor/build.prop
 
 echo "Applying SELinux policy"
+SELinuxPolicy="(allow gmscore_app self (vsock_socket (read write create connect)))"
+SELinuxPolicy="${SELinuxPolicy}\n(allow gmscore_app device_config_runtime_native_boot_prop (file (read)))"
+SELinuxPolicy="${SELinuxPolicy}\n(allow gmscore_app system_server_tmpfs (dir (search)))"
+SELinuxPolicy="${SELinuxPolicy}\n(allow gmscore_app system_server_tmpfs (file (open)))"
 # Sed will remove the SELinux policy for plat_sepolicy.cil, preserve policy using cp
 cp $InstallDir/etc/selinux/plat_sepolicy.cil $InstallDir/etc/selinux/plat_sepolicy_new.cil
-sed -i 's/(allow gmscore_app self (process (ptrace)))/(allow gmscore_app self (process (ptrace)))\n(allow gmscore_app self (vsock_socket (read write create connect)))\n(allow gmscore_app device_config_runtime_native_boot_prop (file (read)))/g' $InstallDir/etc/selinux/plat_sepolicy_new.cil
+sed -i "s/(allow gmscore_app self (process (ptrace)))/(allow gmscore_app self (process (ptrace)))\n${SELinuxPolicy}/g" $InstallDir/etc/selinux/plat_sepolicy_new.cil
 cp $InstallDir/etc/selinux/plat_sepolicy_new.cil $InstallDir/etc/selinux/plat_sepolicy.cil
 rm $InstallDir/etc/selinux/plat_sepolicy_new.cil
 


### PR DESCRIPTION
Fix SELinux Policy violation in WSA 1.8.32828:
```
adb shell
$ su
# cat /proc/kmsg
... avc:  denied  { search } for  pid=4036 comm="RenderThread" name="/" dev="virtiofs" ino=1 scontext=u:r:gmscore_app:s0:c512,c768 tcontext=u:object_r:system_server_tmpfs:s0 tclass=dir permissive=1
... avc:  denied  { open } for  pid=4036 comm="RenderThread" path="/mnt/shared_mem/gralloc_..." dev="virtiofs" ino=0 scontext=u:r:gmscore_app:s0:c512,c768 tcontext=u:object_r:system_server_tmpfs:s0 tclass=file permissive=1
```

Fix #123, Fix #126, Fix #127, Fix #128, Fix #134